### PR TITLE
Mise a jour des liens des prestataires exterieurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿# Modèle Mésange
 
 Le modèle macro-économétrique Mésange a été co-développé par l’Insee et la DG Trésor dans le but, entre autres, de réaliser des évaluations ex ante de l’impact de différentes mesures de politique économique sur les grandeurs macroéconomiques comme l’emploi, le PIB ou les prix. Il permet également de modéliser les conséquences de chocs externes, comme les variations du taux de change ou du prix du pétrole.
-L'utilisation du modèle Mésange se fait à l'aide du logiciel économétrique TROLL (© Massachussets Institute of Technology and © INTEX 2011 et au-delà) et de l'HENDYPLAN TOOLBOX (© HENDYPLAN, 1994 et au-delà). Il est développé par la société Intex Solutions (http://www.intex.com/troll/) et commercialisé en Europe par la société Hendyplan (http://www.hendyplan.com/troll-software/).
+L'utilisation du modèle Mésange se fait à l'aide du logiciel économétrique TROLL (© Massachussets Institute of Technology and © INTEX 2011 et au-delà) et de l'HENDYPLAN TOOLBOX (© HENDYPLAN, 1994 et au-delà). Il est développé par la société Intex Solutions (https://www.intex.com/troll/home.htm) et commercialisé en Europe par la société Hendyplan (http://www.hendyplan.com/).
 
 En aucun cas, il ne pourra être considéré que ce modèle indique la position de l'administration sur l'interprétation de la législation fiscale ou sociale ou toute autre question et lui être opposable.
 En particulier, les paramètres de la législation socio-fiscale et leur application ne sauraient constituer une norme de référence sociale ou fiscale. 


### PR DESCRIPTION
Les liens actuels renvoient vers des pages d'erreur.

* Le site de la société Intex Solutions requiert désormais le nom de fichier `home.htm` dans l'URL et supporte le SSL.
* Le site de la société Hendyplan ne semble plus avoir de page dédiée à l'Hendyplan Toolbox et référence simplement l'outil `Troll-addons` sur sa page d'accueil.
